### PR TITLE
Add preview mode

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10,7 +10,9 @@ import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
 
 
 export namespace Components {
-  interface ManifoldInvoices {}
+  interface ManifoldInvoices {
+    'preview'?: boolean;
+  }
 }
 
 declare global {
@@ -27,7 +29,9 @@ declare global {
 }
 
 declare namespace LocalJSX {
-  interface ManifoldInvoices {}
+  interface ManifoldInvoices {
+    'preview'?: boolean;
+  }
 
   interface IntrinsicElements {
     'manifold-invoices': ManifoldInvoices;

--- a/src/components/manifold-invoices/manifold-invoices.tsx
+++ b/src/components/manifold-invoices/manifold-invoices.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Element, State } from '@stencil/core';
+import { Component, h, Element, Prop, State } from '@stencil/core';
 import { Connection } from '@manifoldco/manifold-init-types/types/v0';
 
 import query from './invoices.graphql';
@@ -21,6 +21,7 @@ export class ManifoldInvoices {
   @Element() el: HTMLElement;
   @State() data?: InvoicesQuery;
   @State() selectedId?: string;
+  @Prop() preview?: boolean;
 
   connection: Connection;
 
@@ -37,10 +38,13 @@ export class ManifoldInvoices {
   }
 
   async fetchInvoices() {
-    const res = await this.connection.graphqlFetch<InvoicesQuery>({
-      query,
-      variables: { first: 100, after: '' },
-    });
+    const res = await this.connection.graphqlFetch<InvoicesQuery>(
+      {
+        query,
+        variables: { first: 100, after: '' },
+      },
+      { headers: { ...(this.preview ? { 'X-Manifold-Sample': 'Platform' } : {}) } }
+    );
 
     if (res.data) {
       this.data = res.data;

--- a/src/index.html
+++ b/src/index.html
@@ -11,8 +11,8 @@
     <link rel="stylesheet" href="/build/manifold-invoices.css" />
     <style>
       :root {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+          Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       }
     </style>
 
@@ -32,6 +32,6 @@
   </head>
   <body>
     <manifold-init env="stage"></manifold-init>
-    <manifold-invoices></manifold-invoices>
+    <manifold-invoices preview></manifold-invoices>
   </body>
 </html>


### PR DESCRIPTION
## Change
I was going to style, then realized this was necessary either way.

**Before**
![Screen Shot 2020-05-06 at 15 22 48](https://user-images.githubusercontent.com/1369770/81230219-4d2b8280-8fae-11ea-8a18-d5954e892888.png)



**After**

![Screen Shot 2020-05-06 at 15 22 53](https://user-images.githubusercontent.com/1369770/81230204-46047480-8fae-11ea-81c5-44d2c5f3d360.png)


## Testing

Adding `preview` hides/shows preview data
