### PR TITLE
Bump npm version _first_, then CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       # Make sure types are valid
       - run: npm install
       - run: npm run typecheck
+      - run: npm version ${GITHUB_REF#refs/tags/v}
       - run: npm run changelog:release -- ${GITHUB_REF#refs/tags/v}
       - name: Commit changes (if any)
         uses: EndBug/add-and-commit@v4
@@ -23,7 +24,8 @@ jobs:
           author_name: 'manifold-dangerzone'
           author_email: 'admin+github-bot-dangerzone@manifold.co'
           message: '🤖 Update CHANGELOG'
-      - run: npm version from-git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: make package
       - run: 'echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc'
       - run: 'npm publish ./pkg --tag latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.1.4] - 2020-05-09
 ### Added
 - Collapsible rows
 - Styling improvements
@@ -17,5 +15,4 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/manifoldco/manifold-invoices/compare/v0.1.4...HEAD
-[0.1.4]: https://github.com/manifoldco/manifold-invoices/compare/v0.0.1...v0.1.4
+[Unreleased]: https://github.com/manifoldco/manifold-invoices/compare/v0.0.1...HEAD

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# <manifold-invoices>
+# &lt;manifold-invoices&gt;
 
 A web component allowing Checkout users to view their invoices.


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

More GitHub Actions experiments! I goofed and mixed up the order. We should run the `npm version` _first_, then bump the CHANGELOG from that version (when you bump CHANGELOG first & commit, `npm version from-git` fails because the new commit no longer has the tag)).

This should be reversed:

![Screen Shot 2020-05-07 at 11 30 23](https://user-images.githubusercontent.com/1369770/81326018-64be4600-9056-11ea-8731-0b0eccc3d5c9.png)


<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Merge it & see what happens
<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

- [ ] [CHANGELOG](./CHANGELOG.md) updated
